### PR TITLE
fix: Xcode 14.3 compatibility.

### DIFF
--- a/DetoxSync/DetoxSync/ReactNativeSupport/DTXReactNativeSupport.m
+++ b/DetoxSync/DetoxSync/ReactNativeSupport/DTXReactNativeSupport.m
@@ -125,7 +125,7 @@ static void _DTXTrackUIManagerQueue(void)
 }
 
 __attribute__((constructor))
-static void _setupRNSupport()
+static void _setupRNSupport(void)
 {
   @autoreleasepool
   {


### PR DESCRIPTION
A function declaration without a prototype is deprecated in all versions of C.