### PR TITLE
Fix race condition with Reanimated library.

### DIFF
--- a/DetoxSync/DetoxSync/ReactNativeSupport/Spies/REASyncUpdateObserver+DTXSpy.m
+++ b/DetoxSync/DetoxSync/ReactNativeSupport/Spies/REASyncUpdateObserver+DTXSpy.m
@@ -50,9 +50,13 @@ static const void* _DTXREASyncUpdateObserverSRKey = &_DTXREASyncUpdateObserverSR
   // Swizzle the original _mounting block to end tracking when it's called
   __weak typeof(self) weakSelf = self;
   swizzledMountingBlock = ^{
+    // Restore the original _mounting block
+    [weakSelf setValue:originalMountingBlock forKey:@"_mounting"];
+
     if (originalMountingBlock) {
       originalMountingBlock();
     }
+
     DTXSingleEventSyncResource* sr = objc_getAssociatedObject(weakSelf, _DTXREASyncUpdateObserverSRKey);
     [sr endTracking];
     objc_setAssociatedObject(weakSelf, _DTXREASyncUpdateObserverSRKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
@@ -62,9 +66,6 @@ static const void* _DTXREASyncUpdateObserverSRKey = &_DTXREASyncUpdateObserverSR
   [self setValue:swizzledMountingBlock forKey:@"_mounting"];
 
   [self __detox_sync_waitAndMountWithTimeout:timeout];
-
-  // Restore the original _mounting block
-  [self setValue:originalMountingBlock forKey:@"_mounting"];
 }
 
 @end


### PR DESCRIPTION
In the original code, the restoration of the original `_mounting` block occurs after the `__detox_sync_waitAndMountWithTimeout:timeout` method call. This leads to the original `_mounting` block being restored after it has potentially been altered by the `__detox_sync_waitAndMountWithTimeout:timeout` method, which is not the desired behavior.

The fix involves moving the restoration of the original `_mounting` block inside the swizzled block (`swizzledMountingBlock`). Now, whenever the swizzled block is executed, the original `_mounting` block is restored first, ensuring the original behavior is retained before any other operations within the swizzled block are performed.

This issue was reported here: https://github.com/wix/Detox/issues/4253 and was reproduced thanks to @ldalzottomp.