### PR TITLE
feat(experimental): add flag to disable main-runloop sync.

### DIFF
--- a/DetoxSync/DetoxSync/SyncManager/DTXSyncManager.m
+++ b/DetoxSync/DetoxSync/SyncManager/DTXSyncManager.m
@@ -191,9 +191,16 @@ static atomic_nstimeinterval _maximumAnimationDuration = ATOMIC_VAR_INIT(1.0);
 		_pendingIdleBlocks = [NSMutableArray new];
 		
 		_trackedThreads = [NSMapTable weakToStrongObjectsMapTable];
+
 		[_trackedThreads setObject:@{@"name": @"Main Thread"} forKey:[NSThread mainThread]];
-		
-		[self _trackCFRunLoop:CFRunLoopGetMain() name:@"Main RunLoop"];
+    
+    //  Experimental: disable main run-loop sync, due to excessive activity on the main thread.
+    BOOL shouldDisableMainRunLoopSync =
+        [NSUserDefaults.standardUserDefaults boolForKey:@"DTXDisableMainRunLoopSync"];
+    if (!shouldDisableMainRunLoopSync) {
+      [self _trackCFRunLoop:CFRunLoopGetMain() name:@"Main RunLoop"];
+    }
+
 		_systemWasBusy = DTXIsSystemBusyNow();
 	}
 }


### PR DESCRIPTION
Use experimental flag `DTXDisableMainRunLoopSync` for testing purposes.