### PR TITLE
fix(iOS): ignore deceleration on scroll-sync.

### DIFF
--- a/DetoxSync/DetoxSync/Spies/UIScrollView+DTXSpy.m
+++ b/DetoxSync/DetoxSync/Spies/UIScrollView+DTXSpy.m
@@ -53,11 +53,8 @@ static const void* _DTXScrollViewSRKey = &_DTXScrollViewSRKey;
 - (void)__detox_sync__scrollViewDidEndDraggingWithDeceleration:(bool)arg1
 {
 	[self __detox_sync__scrollViewDidEndDraggingWithDeceleration:arg1];
-	
-	if(arg1 == NO)
-	{
-		[self __detox_sync_resetSyncResource];
-	}
+
+    [self __detox_sync_resetSyncResource];
 }
 
 - (void)__detox_sync__scrollViewDidEndDecelerating


### PR DESCRIPTION
The scroll-sync resource will reset if the scrolling was ended. If there is any deceleration that matters, it will be handled in the UI sync. 
This fixes an error with `RCTEnhancedScrollView` (new arch) where the scroll-view keeps decelerating forever (natively) even if there's nothing moving on the scroll-view.