### PR TITLE
fix(js-timers): revert old-arch sync resource changes.

### DIFF
--- a/DetoxSync/DetoxSync/ReactNativeSupport/SyncResources/DTXJSTimerSyncResource.m
+++ b/DetoxSync/DetoxSync/ReactNativeSupport/SyncResources/DTXJSTimerSyncResource.m
@@ -6,7 +6,6 @@
 #import "DTXJSTimerSyncResource.h"
 #import "DTXSyncManager-Private.h"
 #import "NSString+SyncResource.h"
-#import "DTXReactNativeSupport.h"
 
 @import ObjectiveC;
 
@@ -55,52 +54,20 @@ static NSString* _prettyTimerDescription(NSNumber* timerID)
     __weak __typeof(self) weakSelf = self;
     Class cls = NSClassFromString(@"RCTTiming");
 
-    if ([DTXReactNativeSupport isNewArchEnabled]) {
-        SEL createTimerForNextFrameSel = NSSelectorFromString(@"createTimerForNextFrame:duration:jsSchedulingTime:repeats:");
-        Method createTimerForNextFrameMethod = class_getInstanceMethod(cls, createTimerForNextFrameSel);
+    SEL createTimerForNextFrameSel = NSSelectorFromString(@"createTimerForNextFrame:duration:jsSchedulingTime:repeats:");
+    Method createTimerForNextFrameMethod = class_getInstanceMethod(cls, createTimerForNextFrameSel);
 
-        void (*orig_createTimerForNextFrame)(id, SEL, NSNumber*, NSTimeInterval, NSDate*, BOOL) = (void*)method_getImplementation(createTimerForNextFrameMethod);
-        method_setImplementation(createTimerForNextFrameMethod, imp_implementationWithBlock(^(id _self, NSNumber* callbackID, NSTimeInterval duration, NSDate* jsSchedulingTime, BOOL repeats) {
-            __strong __typeof(weakSelf) strongSelf = weakSelf;
-            if (strongSelf) {
-                dtx_log_info(@"[DTXJSTimerSyncResource] Before observing timer %@", callbackID);
-                [strongSelf observeTimerWithInstance:_self timerID:callbackID duration:duration repeats:repeats];
-                orig_createTimerForNextFrame(_self, createTimerForNextFrameSel, callbackID, duration, jsSchedulingTime, repeats);
-            } else {
-                orig_createTimerForNextFrame(_self, createTimerForNextFrameSel, callbackID, duration, jsSchedulingTime, repeats);
-            }
-        }));
-    } else {
-        SEL createTimerSel = NSSelectorFromString(@"createTimer:duration:jsSchedulingTime:repeats:");
-        Method createTimerMethod = class_getInstanceMethod(cls, createTimerSel);
-
-        const char* timerArgType = [[cls instanceMethodSignatureForSelector:createTimerSel] getArgumentTypeAtIndex:2];
-        if (strncmp(timerArgType, "d", 1) == 0) {
-            void (*orig_createTimer)(id, SEL, double, NSTimeInterval, double, BOOL) = (void*)method_getImplementation(createTimerMethod);
-            method_setImplementation(createTimerMethod, imp_implementationWithBlock(^(id _self, double timerID, NSTimeInterval duration, double jsDate, BOOL repeats) {
-                __strong __typeof(weakSelf) strongSelf = weakSelf;
-                if (strongSelf) {
-                    dtx_log_info(@"[DTXJSTimerSyncResource] Observing timer %@", @(timerID));
-                    [strongSelf observeTimerWithInstance:_self timerID:@(timerID) duration:duration repeats:repeats];
-                    orig_createTimer(_self, createTimerSel, timerID, duration, jsDate, repeats);
-                } else {
-                    orig_createTimer(_self, createTimerSel, timerID, duration, jsDate, repeats);
-                }
-            }));
+    void (*orig_createTimerForNextFrame)(id, SEL, NSNumber*, NSTimeInterval, NSDate*, BOOL) = (void*)method_getImplementation(createTimerForNextFrameMethod);
+    method_setImplementation(createTimerForNextFrameMethod, imp_implementationWithBlock(^(id _self, NSNumber* callbackID, NSTimeInterval duration, NSDate* jsSchedulingTime, BOOL repeats) {
+        __strong __typeof(weakSelf) strongSelf = weakSelf;
+        if (strongSelf) {
+            dtx_log_info(@"[DTXJSTimerSyncResource] Before observing timer %@", callbackID);
+            [strongSelf observeTimerWithInstance:_self timerID:callbackID duration:duration repeats:repeats];
+            orig_createTimerForNextFrame(_self, createTimerForNextFrameSel, callbackID, duration, jsSchedulingTime, repeats);
         } else {
-            void (*orig_createTimer)(id, SEL, NSNumber*, NSTimeInterval, NSDate*, BOOL) = (void*)method_getImplementation(createTimerMethod);
-            method_setImplementation(createTimerMethod, imp_implementationWithBlock(^(id _self, NSNumber* timerID, NSTimeInterval duration, NSDate* jsDate, BOOL repeats) {
-                __strong __typeof(weakSelf) strongSelf = weakSelf;
-                if (strongSelf) {
-                    dtx_log_info(@"[DTXJSTimerSyncResource] Before observing timer %@", timerID);
-                    [strongSelf observeTimerWithInstance:_self timerID:timerID duration:duration repeats:repeats];
-                    orig_createTimer(_self, createTimerSel, timerID, duration, jsDate, repeats);
-                } else {
-                    orig_createTimer(_self, createTimerSel, timerID, duration, jsDate, repeats);
-                }
-            }));
+            orig_createTimerForNextFrame(_self, createTimerForNextFrameSel, callbackID, duration, jsSchedulingTime, repeats);
         }
-    }
+    }));
 
     SEL deleteTimerSel = NSSelectorFromString(@"deleteTimer:");
     Method deleteTimerMethod = class_getInstanceMethod(cls, deleteTimerSel);

--- a/DetoxSync/DetoxSync/ReactNativeSupport/SyncResources/DTXJSTimerSyncResourceOldArch.m
+++ b/DetoxSync/DetoxSync/ReactNativeSupport/SyncResources/DTXJSTimerSyncResourceOldArch.m
@@ -11,278 +11,271 @@
 #import "NSString+SyncResource.h"
 #import "NSArray+Functional.h"
 #import "_DTXTimerTrampoline.h"
-#import "DTXReactNativeSupport.h"
 
 @import ObjectiveC;
 
-static NSString* _prettyTimerDescription(NSNumber* timerID)
-{
-    return [NSString stringWithFormat:@"JavaScript Timer %@ (Native Implementation)", timerID];
-}
+/// Represents an observed Javascript timer, for internal use of \c DTXJSTimerSyncResourceOldArch.
+@interface JSTimer: NSObject
 
-#pragma mark - Timer Model
-
-@interface JSTimer : NSObject
-
+/// Identifier of the JS timer, as returned from the \c setTimeout / \c setInterval JS methods.
 @property (nonatomic, readonly) NSNumber *timerID;
-@property (nonatomic, readonly) NSTimeInterval duration;
-@property (nonatomic, readonly) BOOL isRecurring;
 
-+ (instancetype)new NS_UNAVAILABLE;
+/// Duration of the JS timer.
+@property (nonatomic, readonly) NSTimeInterval duration;
+
+/// Indicated whether the JS timer is reccuring.
+@property (nonatomic, readonly) BOOL isReccuring;
+
 - (instancetype)init NS_UNAVAILABLE;
-- (instancetype)initWithTimerID:(NSNumber *)timerID duration:(NSTimeInterval)duration isRecurring:(BOOL)isRecurring NS_DESIGNATED_INITIALIZER;
+
+- (instancetype)initWithTimerID:(NSNumber *)timerID duration:(NSTimeInterval)duration
+                    isReccuring:(BOOL)isReccuring NS_DESIGNATED_INITIALIZER;
+
+/// Returns a JSON dictionary that describes the timer.
+- (DTXBusyResource *)jsonDescription;
 
 @end
 
 @implementation JSTimer
 
-- (instancetype)initWithTimerID:(NSNumber *)timerID duration:(NSTimeInterval)duration isRecurring:(BOOL)isRecurring {
-    if ((self = [super init])) {
+- (instancetype)initWithTimerID:(NSNumber *)timerID duration:(NSTimeInterval)duration
+                    isReccuring:(BOOL)isReccuring {
+    if (self = [super init]) {
         _timerID = timerID;
         _duration = duration;
-        _isRecurring = isRecurring;
+        _isReccuring = isReccuring;
     }
     return self;
 }
 
-@end
-
-#pragma mark - Timer Dictionary
-
-@interface TimerDictionary : NSMutableDictionary
-
-@property (nonatomic, strong) NSMutableDictionary *storage;
-@property (nonatomic, strong) NSMutableArray<JSTimer *> *activeTimers;
-@property (nonatomic, weak) DTXJSTimerSyncResourceOldArch *syncResource;
-
-- (instancetype)initWithSyncResource:(DTXJSTimerSyncResourceOldArch *)syncResource;
-- (void)addObservedTimer:(JSTimer *)timer;
-- (void)removeObservedTimer:(NSNumber *)timerID;
-
-@end
-
-@implementation TimerDictionary
-
-- (instancetype)initWithSyncResource:(DTXJSTimerSyncResourceOldArch *)syncResource {
-    if ((self = [super init])) {
-        _storage = [NSMutableDictionary new];
-        _activeTimers = [NSMutableArray new];
-        _syncResource = syncResource;
-    }
-    return self;
-}
-
-#pragma mark NSMutableDictionary Required Methods
-
-- (NSUInteger)count {
-    return _storage.count;
-}
-
-- (id)objectForKey:(id)aKey {
-    return [_storage objectForKey:aKey];
-}
-
-- (NSEnumerator *)keyEnumerator {
-    return [_storage keyEnumerator];
-}
-
-- (void)setObject:(id)anObject forKey:(id)aKey {
-    [_storage setObject:anObject forKey:aKey];
-}
-
-- (void)removeObjectForKey:(id)aKey {
-    [self removeObservedTimer:aKey];
-    [_storage removeObjectForKey:aKey];
-}
-
-- (NSArray *)allValues {
-    return [_storage allValues];
-}
-
-- (NSArray *)allKeys {
-    return [_storage allKeys];
-}
-
-- (void)removeAllObjects {
-    [_storage removeAllObjects];
-    [_activeTimers removeAllObjects];
-}
-
-#pragma mark Timer Observation Methods
-
-- (void)addObservedTimer:(JSTimer *)timer {
-    [_syncResource performUpdateBlock:^NSUInteger{
-        [_activeTimers addObject:timer];
-        return [self.syncResource _busyCount];
-    } eventIdentifier:_DTXStringReturningBlock([timer.timerID stringValue])
-                     eventDescription:_DTXStringReturningBlock([self.syncResource resourceName])
-                    objectDescription:_DTXStringReturningBlock(_prettyTimerDescription(timer.timerID))
-                additionalDescription:nil];
-}
-
-- (void)removeObservedTimer:(NSNumber *)timerID {
-    [_syncResource performUpdateBlock:^NSUInteger{
-        self.activeTimers = [[self.activeTimers filter:^BOOL(JSTimer *timer) {
-            if ([timer.timerID isEqual:timerID]) {
-                DTXSyncResourceVerboseLog(@"⏲ Removing observed timer: (%@)", timer);
-                return NO;
-            }
-            return YES;
-        }] mutableCopy];
-
-        return [self.syncResource _busyCount];
-    } eventIdentifier:_DTXStringReturningBlock([timerID stringValue])
-                     eventDescription:_DTXStringReturningBlock([self.syncResource resourceName])
-                    objectDescription:_DTXStringReturningBlock(_prettyTimerDescription(timerID))
-                additionalDescription:nil];
+- (DTXBusyResource *)jsonDescription {
+    return @{
+        @"timer_id": self.timerID,
+        @"duration": @(self.duration),
+        @"is_recurring": @(self.isReccuring)
+    };
 }
 
 @end
 
 @interface DTXJSTimerSyncResourceOldArch ()
 
-@property (nonatomic, strong) NSMapTable<id, TimerDictionary *> *observations;
+- (NSUInteger)_busyCount;
 
 @end
 
-@implementation DTXJSTimerSyncResourceOldArch {
-    NSMapTable<id, TimerDictionary *> *_observations;
+static NSString* _prettyTimerDescription(NSNumber* timerID)
+{
+    return [NSString stringWithFormat:@"JavaScript Timer %@ (Native Implementation)", timerID];
 }
 
-- (instancetype)init {
+@interface _DTXJSTimerObservationWrapper : NSObject @end
+@implementation _DTXJSTimerObservationWrapper
+{
+    NSMutableArray<JSTimer *> *_observedTimers;
+    NSMutableDictionary *_timers;
+
+    __weak DTXJSTimerSyncResourceOldArch* _syncResource;
+}
+
+- (instancetype)initWithTimers:(NSMutableDictionary*)timers syncResource:(DTXJSTimerSyncResourceOldArch*)syncResource
+{
     self = [super init];
-    if(self) {
+    if(self)
+    {
+        _timers = timers;
+        _observedTimers = [NSMutableArray new];
+        _syncResource = syncResource;
+    }
+
+    return self;
+}
+
+- (NSMethodSignature *)methodSignatureForSelector:(SEL)aSelector
+{
+    NSMethodSignature* sig = [super methodSignatureForSelector:aSelector];
+
+    if(sig == nil)
+    {
+        sig = [_timers methodSignatureForSelector:aSelector];
+    }
+
+    return sig;
+}
+
+- (void)forwardInvocation:(NSInvocation *)anInvocation
+{
+    [anInvocation invokeWithTarget:_timers];
+}
+
+- (void)addObservedTimer:(JSTimer *)timer {
+    [_observedTimers addObject:timer];
+}
+
+- (NSUInteger)countOfObservedTimers
+{
+    return _observedTimers.count;
+}
+
+- (void)removeObjectForKey:(NSNumber*)aKey
+{
+    [_syncResource
+     performUpdateBlock:^ {
+        _observedTimers = [[_observedTimers filter:^BOOL(JSTimer *timer) {
+            if (timer.timerID == aKey) {
+                DTXSyncResourceVerboseLog(@"⏲ Removing observed timer: (%@)", timer);
+                return NO;
+            }
+            return YES;
+        }] mutableCopy];
+
+        return [_syncResource _busyCount];
+    }
+     eventIdentifier:_DTXStringReturningBlock(aKey.stringValue)
+     eventDescription:_DTXStringReturningBlock([_syncResource resourceName])
+     objectDescription:_DTXStringReturningBlock(_prettyTimerDescription(aKey))
+     additionalDescription:nil];
+
+    [_timers removeObjectForKey:aKey];
+}
+
+@end
+
+@implementation DTXJSTimerSyncResourceOldArch
+{
+    NSMapTable<id, _DTXJSTimerObservationWrapper*>* _observations;
+}
+
+- (NSMapTable<id,id> *)observations
+{
+    return (id)_observations;
+}
+
+- (NSString*)failureReasonForDuration:(NSTimeInterval)duration repeats:(BOOL)repeats
+{
+    if(duration == 0)
+    {
+        return @"duration==0";
+    }
+    else if(repeats == YES)
+    {
+        return @"repeats==true";
+    }
+    else if(duration > DTXSyncManager.maximumTimerIntervalTrackingDuration)
+    {
+        return [NSString stringWithFormat:@"duration(%@)>%@",
+                @(duration),
+                @(DTXSyncManager.maximumTimerIntervalTrackingDuration)];
+    }
+
+    return @"";
+}
+
+- (NSUInteger)_busyCount
+{
+    NSUInteger observedTimersCount = 0;
+
+    for(_DTXJSTimerObservationWrapper* wrapper in _observations.objectEnumerator)
+    {
+        observedTimersCount += wrapper.countOfObservedTimers;
+    }
+
+    return observedTimersCount;
+}
+
+- (instancetype)init
+{
+    self = [super init];
+    if(self)
+    {
         _observations = [NSMapTable mapTableWithKeyOptions:NSMapTableWeakMemory valueOptions:NSMapTableStrongMemory];
-        [self setupTimerObservation];
+
+        __weak __typeof(self) weakSelf = self;
+
+        Class cls = NSClassFromString(@"RCTTiming");
+        SEL createTimerSel = NSSelectorFromString(@"createTimer:duration:jsSchedulingTime:repeats:");
+        Method m = class_getInstanceMethod(cls, createTimerSel);
+
+        // Check if the createTimer interface is using doubles or NSObjects.
+        // Earlier versions of react native use NSObjects for the timer and
+        // date params, while later versions use doubles for these.
+        const char* timerArgType = [[cls instanceMethodSignatureForSelector:createTimerSel] getArgumentTypeAtIndex:2];
+        if (strncmp(timerArgType, "d", 1) == 0)
+        {
+            void (*orig_createTimer)(id, SEL, double, NSTimeInterval, double, BOOL) = (void*)method_getImplementation(m);
+            method_setImplementation(m, imp_implementationWithBlock(^(id _self, double timerID, NSTimeInterval duration, double jsDate, BOOL repeats) {
+                __strong __typeof(weakSelf) strongSelf = weakSelf;
+                [strongSelf attachObservation:_self timerID:@(timerID) duration:duration repeats:repeats];
+                orig_createTimer(_self, createTimerSel, timerID, duration, jsDate, repeats);
+            }));
+        }
+        else
+        {
+            void (*orig_createTimer)(id, SEL, NSNumber*, NSTimeInterval, NSDate*, BOOL) = (void*)method_getImplementation(m);
+            method_setImplementation(m, imp_implementationWithBlock(^(id _self, NSNumber* timerID, NSTimeInterval duration, NSDate* jsDate, BOOL repeats) {
+                __strong __typeof(weakSelf) strongSelf = weakSelf;
+                [strongSelf attachObservation:_self timerID:timerID duration:duration repeats:repeats];
+                orig_createTimer(_self, createTimerSel, timerID, duration, jsDate, repeats);
+            }));
+        }
     }
     return self;
 }
 
-- (void)setupTimerObservation {
-    __weak __typeof(self) weakSelf = self;
+- (void)attachObservation:(id)_self timerID:(NSNumber *)timerID duration:(NSTimeInterval)duration repeats:(BOOL)repeats
+{
+    [self performUpdateBlock:^ {
+        _DTXJSTimerObservationWrapper* _observationWrapper = [self->_observations objectForKey:_self];
 
-    Class cls = NSClassFromString(@"RCTTiming");
-
-    if ([DTXReactNativeSupport isNewArchEnabled]) {
-        // New Architecture: Only swizzle createTimerForNextFrame
-        SEL createTimerForNextFrameSel = NSSelectorFromString(@"createTimerForNextFrame:duration:jsSchedulingTime:repeats:");
-        Method createTimerForNextFrameMethod = class_getInstanceMethod(cls, createTimerForNextFrameSel);
-
-        void (*orig_createTimerForNextFrame)(id, SEL, NSNumber*, NSTimeInterval, NSDate*, BOOL) = (void*)method_getImplementation(createTimerForNextFrameMethod);
-        method_setImplementation(createTimerForNextFrameMethod, imp_implementationWithBlock(^(id _self, NSNumber* callbackID, NSTimeInterval duration, NSDate* jsSchedulingTime, BOOL repeats) {
-            __strong __typeof(weakSelf) strongSelf = weakSelf;
-            if (strongSelf != nil) {
-                [strongSelf observeTimerWithInstance:_self timerID:callbackID duration:duration repeats:repeats];
-            }
-
-            orig_createTimerForNextFrame(_self, createTimerForNextFrameSel, callbackID, duration, jsSchedulingTime, repeats);
-        }));
-    } else {
-        // Legacy Architecture: Only swizzle createTimer
-        SEL createTimerSel = NSSelectorFromString(@"createTimer:duration:jsSchedulingTime:repeats:");
-        Method createTimerMethod = class_getInstanceMethod(cls, createTimerSel);
-
-        const char* timerArgType = [[cls instanceMethodSignatureForSelector:createTimerSel] getArgumentTypeAtIndex:2];
-        if (strncmp(timerArgType, "d", 1) == 0) {
-            void (*orig_createTimer)(id, SEL, double, NSTimeInterval, double, BOOL) = (void*)method_getImplementation(createTimerMethod);
-            method_setImplementation(createTimerMethod, imp_implementationWithBlock(^(id _self, double timerID, NSTimeInterval duration, double jsDate, BOOL repeats) {
-                __strong __typeof(weakSelf) strongSelf = weakSelf;
-                if (strongSelf != nil) {
-                    [strongSelf observeTimerWithInstance:_self timerID:@(timerID) duration:duration repeats:repeats];
-                }
-                orig_createTimer(_self, createTimerSel, timerID, duration, jsDate, repeats);
-            }));
-        } else {
-            void (*orig_createTimer)(id, SEL, NSNumber*, NSTimeInterval, NSDate*, BOOL) = (void*)method_getImplementation(createTimerMethod);
-            method_setImplementation(createTimerMethod, imp_implementationWithBlock(^(id _self, NSNumber* timerID, NSTimeInterval duration, NSDate* jsDate, BOOL repeats) {
-                __strong __typeof(weakSelf) strongSelf = weakSelf;
-                if (strongSelf != nil) {
-                    [strongSelf observeTimerWithInstance:_self timerID:timerID duration:duration repeats:repeats];
-                }
-
-                orig_createTimer(_self, createTimerSel, timerID, duration, jsDate, repeats);
-            }));
+        if(_observationWrapper == nil)
+        {
+            _observationWrapper = [[_DTXJSTimerObservationWrapper alloc] initWithTimers:[_self valueForKey:@"_timers"] syncResource:self];
+            [_self setValue:_observationWrapper forKey:@"_timers"];
+            [self->_observations setObject:_observationWrapper forKey:_self];
         }
-    }
 
-    // Swizzle deleteTimer: (common for both architectures)
-    SEL deleteTimerSel = NSSelectorFromString(@"deleteTimer:");
-    Method deleteTimerMethod = class_getInstanceMethod(cls, deleteTimerSel);
+        if(duration > 0 && duration <= DTXSyncManager.maximumTimerIntervalTrackingDuration && repeats == NO)
+        {
+            DTXSyncResourceVerboseLog(@"⏲ Observing timer “%@” duration: %@ repeats: %@", timerID, @(duration), @(repeats));
 
-    void (*orig_deleteTimer)(id, SEL, double) = (void*)method_getImplementation(deleteTimerMethod);
-    method_setImplementation(deleteTimerMethod, imp_implementationWithBlock(^(id _self, double timerID) {
-        orig_deleteTimer(_self, deleteTimerSel, timerID);
-
-        __strong __typeof(weakSelf) strongSelf = weakSelf;
-        if (strongSelf != nil) {
-            TimerDictionary *timerDict = [strongSelf.observations objectForKey:_self];
-            if (timerDict != nil) {
-                [timerDict removeObservedTimer:@(timerID)];
-            }
+            [_observationWrapper addObservedTimer:[[JSTimer alloc] initWithTimerID:timerID
+                                                                          duration:duration
+                                                                       isReccuring:repeats]];
         }
-    }));
-}
-
-- (void)observeTimerWithInstance:(id)instance timerID:(NSNumber *)timerID duration:(NSTimeInterval)duration repeats:(BOOL)repeats {
-    TimerDictionary *timerDict = [_observations objectForKey:instance];
-    if(timerDict == nil) {
-        timerDict = [[TimerDictionary alloc] initWithSyncResource:self];
-        [instance setValue:timerDict forKey:@"_timers"];
-        [_observations setObject:timerDict forKey:instance];
-    }
-    if(duration > DTXSyncManager.minimumTimerIntervalTrackingDuration && duration <= DTXSyncManager.maximumTimerIntervalTrackingDuration && repeats == NO) {
-        DTXSyncResourceVerboseLog(@"⏲ Observing timer \"%@\" duration: %@ repeats: %@", timerID, @(duration), @(repeats));
-
-        [timerDict addObservedTimer:[[JSTimer alloc] initWithTimerID:timerID duration:duration isRecurring:repeats]];
-    } else {
-        DTXSyncResourceVerboseLog(@"⏲ Ignoring timer \"%@\" failure reason: \"%@\"", timerID, [self failureReasonForDuration:duration repeats:repeats]);
-    }
-}
-
-- (NSString*)failureReasonForDuration:(NSTimeInterval)duration repeats:(BOOL)repeats {
-    if(duration < DTXSyncManager.minimumTimerIntervalTrackingDuration) {
-        return [NSString stringWithFormat:@"duration(%@)<%@", @(duration), @(DTXSyncManager.minimumTimerIntervalTrackingDuration)];
-    } else if(repeats == YES) {
-        return @"repeats==true";
-    } else if(duration > DTXSyncManager.maximumTimerIntervalTrackingDuration) {
-        return [NSString stringWithFormat:@"duration(%@)>%@", @(duration), @(DTXSyncManager.maximumTimerIntervalTrackingDuration)];
-    }
-    return @"";
-}
-
-- (NSUInteger)_busyCount {
-    NSUInteger count = 0;
-    for (TimerDictionary *dict in _observations.objectEnumerator) {
-        count += dict.activeTimers.count;
-    }
-    return count;
-}
-
-- (NSString*)syncResourceDescription {
-    NSMutableArray<NSString*>* descriptions = [NSMutableArray new];
-    for (TimerDictionary *dict in _observations.objectEnumerator) {
-        for (JSTimer *timer in dict.activeTimers) {
-            [descriptions addObject:timer.description];
+        else
+        {
+            DTXSyncResourceVerboseLog(@"⏲ Ignoring timer “%@” failure reason: \"%@\"", timerID, [self failureReasonForDuration:duration repeats:repeats]);
         }
+
+        return [self _busyCount];
     }
-    return [descriptions componentsJoinedByString:@"\n⏱ "];
+             eventIdentifier:_DTXStringReturningBlock(timerID.stringValue)
+            eventDescription:_DTXStringReturningBlock(self.resourceName)
+           objectDescription:_DTXStringReturningBlock(_prettyTimerDescription(timerID)) additionalDescription:nil];
+}
+
+- (NSString*)syncResourceDescription
+{
+    NSArray<NSString*>* timers = [[_observations.objectEnumerator.allObjects valueForKeyPath:@"@distinctUnionOfObjects._observedTimers"] firstObject];
+
+    return [timers componentsJoinedByString:@"\n⏱ "];
 }
 
 - (DTXBusyResource *)jsonDescription {
-    NSMutableArray *timerDescriptions = [NSMutableArray new];
-    for (TimerDictionary *dict in _observations.objectEnumerator) {
-        for (JSTimer *timer in dict.activeTimers) {
-            [timerDescriptions addObject:@{
-                @"timer_id": timer.timerID,
-                @"duration": @(timer.duration),
-            }];
-        }
-    }
+    NSArray<NSArray<JSTimer *> *> *observedTimers =
+    [_observations.objectEnumerator.allObjects
+     valueForKeyPath:@"@distinctUnionOfObjects._observedTimers"];
+
+    NSArray *flattenedObservedTimers = [observedTimers valueForKeyPath:@"@unionOfArrays.self"];
+    NSArray *timersDescriptions = [flattenedObservedTimers
+                                   map:^NSDictionary *(_DTXTimerTrampoline *timer) {
+        return [timer jsonDescription];
+    }];
 
     return @{
         NSString.dtx_resourceNameKey: @"js_timers",
         NSString.dtx_resourceDescriptionKey: @{
-            @"timers": timerDescriptions
+            @"timers": timersDescriptions
         }
     };
 }


### PR DESCRIPTION
Revert the old-arch's JS timers sync resource code to the state before https://github.com/wix-incubator/DetoxSync/pull/77